### PR TITLE
Use new Android Studio project structure

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ function run() {
   var completeDeferred = Q.defer();
   var promises = [];
   var options = {
-    dest: 'platforms/android/res/'
+    dest: 'platforms/android/app/src/main/res/'
   };
 
   display.header('Generating Android resources');


### PR DESCRIPTION
The path to the `res` folder has change since cordova-android 7 was released, this fixes it